### PR TITLE
Remove config from itof constructor

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -46,10 +46,9 @@
 CameraItof::CameraItof(
     std::shared_ptr<aditof::DepthSensorInterface> depthSensor,
     std::vector<std::shared_ptr<aditof::StorageInterface>> &eeproms,
-    std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>> &tSensors,
-    std::string config)
+    std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>> &tSensors)
     : m_depthSensor(depthSensor), m_devStarted(false),
-      m_modechange_framedrop_count(0), m_config(config) {
+      m_modechange_framedrop_count(0) {
     m_details.mode = "short_throw";
     m_details.cameraId = "";
 
@@ -100,7 +99,8 @@ aditof::Status CameraItof::initialize() {
     }
 
     // Parse config.json
-    std::ifstream ifs(m_config.c_str());
+    std::string config = m_controls["initialization_config"];
+    std::ifstream ifs(config.c_str());
     std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
     std::vector<std::pair<std::string, int32_t>> device_settings;
 
@@ -152,8 +152,8 @@ aditof::Status CameraItof::initialize() {
         if (cJSON_IsString(json_vaux_voltage) && (json_vaux_voltage->valuestring != NULL)) {
             device_settings.push_back(std::make_pair(json_vaux_voltage->string, atoi(json_vaux_voltage->valuestring)));
         }
-    } else if (!m_config.empty()) {
-        LOG(ERROR) << "Couldn't parse " << m_config.c_str();
+    } else if (!config.empty()) {
+        LOG(ERROR) << "Couldn't parse config file: " << config.c_str();
         return Status::GENERIC_ERROR;
     }
 

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -624,6 +624,11 @@ std::tuple<aditof::Status, int, int, int> CameraItof::loadConfigData(void) {
     return std::make_tuple(aditof::Status::OK, calFileSize, jsonFileSize, iniFileSize);
 }
 
+void CameraItof::freeConfigData(void)
+{
+    // TO DO:
+}
+
 aditof::Status CameraItof::isValidFrame(const int numTotalFrames) {
     using namespace aditof;
 

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -79,8 +79,7 @@ class CameraItof : public aditof::Camera {
     CameraItof(std::shared_ptr<aditof::DepthSensorInterface> depthSensor,
                std::vector<std::shared_ptr<aditof::StorageInterface>> &eeproms,
                std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>>
-                   &tSensors,
-               std::string config);
+                   &tSensors);
     ~CameraItof();
 
   public: // implements Camera
@@ -276,7 +275,6 @@ class CameraItof : public aditof::Camera {
     bool m_devStarted;
     bool m_eepromInitialized;
     bool m_tempSensorInitialized;
-    std::string m_config;
     // Calibration m_calibration;
 
     uint8_t *m_calData = NULL;


### PR DESCRIPTION
Constructor of CameraItof is not public so we can't pass the 'config' parameter through the constructor.
But the controls mechanism is available and can be used. There already exists a control for the configuration file name.