### PR TITLE
apps/uvc-gadget: Avoid overwriting the old request

### DIFF
--- a/apps/uvc-app/uvc-gadget.cpp
+++ b/apps/uvc-app/uvc-gadget.cpp
@@ -1400,6 +1400,7 @@ static int uvc_events_process_data(struct uvc_device *dev,
           }
 
           // reset to default
+          clientRequestBlob.clear();
           clientRequestBlobLength = 0;
           clientRequestCharsRead = 0;
           hasClientRequestLengthSet = false;


### PR DESCRIPTION
First clear the old request. Otherwise new messages append/overwrite the
old one thus creating a mix of old and new messages which is clearly not
desired.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>