### PR TITLE
sdk: connections: Fix burst transfer address parameter

### DIFF
--- a/sdk/src/connections/network/network_depth_sensor.cpp
+++ b/sdk/src/connections/network/network_depth_sensor.cpp
@@ -422,7 +422,7 @@ aditof::Status NetworkDepthSensor::readRegisters(const uint16_t *address,
     net->send_buff.set_func_name("ReadRegisters");
     net->send_buff.add_func_int32_param(static_cast<::google::int32>(length));
     net->send_buff.add_func_int32_param(static_cast<::google::int32>(burst));
-    net->send_buff.add_func_bytes_param(address, length * sizeof(uint16_t));
+    net->send_buff.add_func_bytes_param(address, burst ? 2 : length * sizeof(uint16_t));
     net->send_buff.add_func_bytes_param(data, length * sizeof(uint16_t));
     net->send_buff.set_expect_reply(true);
 
@@ -468,7 +468,7 @@ aditof::Status NetworkDepthSensor::writeRegisters(const uint16_t *address,
     net->send_buff.set_func_name("WriteRegisters");
     net->send_buff.add_func_int32_param(static_cast<::google::int32>(length));
     net->send_buff.add_func_int32_param(static_cast<::google::int32>(burst));
-    net->send_buff.add_func_bytes_param(address, length * sizeof(uint16_t));
+    net->send_buff.add_func_bytes_param(address, burst ? 2 : length * sizeof(uint16_t));
     net->send_buff.add_func_bytes_param(data, length * sizeof(uint16_t));
     net->send_buff.set_expect_reply(true);
 

--- a/sdk/src/connections/usb/windows/usb_depth_sensor_windows.cpp
+++ b/sdk/src/connections/usb/windows/usb_depth_sensor_windows.cpp
@@ -701,7 +701,7 @@ aditof::Status UsbDepthSensor::readRegisters(const uint16_t *address,
     requestMsg.set_func_name(usb_payload::FunctionName::READ_REGISTERS);
     requestMsg.add_func_int32_param(static_cast<::google::int32>(length));
     requestMsg.add_func_int32_param(static_cast<::google::int32>(burst));
-    requestMsg.add_func_bytes_param(address, length * sizeof(uint16_t));
+    requestMsg.add_func_bytes_param(address, burst ? 2 : length * sizeof(uint16_t));
 
     // Send request
     std::string requestStr;
@@ -753,7 +753,7 @@ aditof::Status UsbDepthSensor::writeRegisters(const uint16_t *address,
     requestMsg.set_func_name(usb_payload::FunctionName::WRITE_REGISTERS);
     requestMsg.add_func_int32_param(static_cast<::google::int32>(length));
     requestMsg.add_func_int32_param(static_cast<::google::int32>(burst));
-    requestMsg.add_func_bytes_param(address, length * sizeof(uint16_t));
+    requestMsg.add_func_bytes_param(address, burst ? 2 : length * sizeof(uint16_t));
     requestMsg.add_func_bytes_param(data, length * sizeof(uint16_t));
 
     // Send request


### PR DESCRIPTION
For transfers where burst is true the address parameter
should take only a pointer to a variable specifying start
address for burst transfer. Only for non burst transfers the
address is a pointer to an array.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>