### PR TITLE
sdk: src: cameras: camera_itof.cpp: Disable config apply

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -222,8 +222,9 @@ aditof::Status CameraItof::start() {
     // only setmode and start the camera.
     if (!m_CameraProgrammed) {
         CalibrationItof calib(m_depthSensor);
-
-        status = calib.writeConfiguration(m_sensorFirmwareFile);
+        
+        //TODO: For now disable writeConfiguration. Is performed by driver
+        //status = calib.writeConfiguration(m_sensorFirmwareFile);
         if (Status::OK != status) {
             LOG(ERROR) << "Error writing camera firmware.";
             return status;


### PR DESCRIPTION
Right now the configuration required for NXP platform is written
by the Linux sensor driver. Camera flash memory contain a configuration
invalid for NXP so disable writing for now.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>