### PR TITLE
examples: first-frame: main.cpp: Add call to loadModuleData

### DIFF
--- a/examples/first-frame/main.cpp
+++ b/examples/first-frame/main.cpp
@@ -81,9 +81,17 @@ int main(int argc, char *argv[]) {
     }
 
     auto camera = cameras.front();
+
     status = camera->initialize();
     if (status != Status::OK) {
         LOG(ERROR) << "Could not initialize camera!";
+        return 0;
+    }
+
+    // load configuration data from module memory
+    status = camera->setControl("loadModuleData", "call");
+    if (status != Status::OK) {
+        LOG(INFO) << "No CCB/CFG data found in camera module,";
         return 0;
     }
 


### PR DESCRIPTION
The default path for json configuration file is initialized with empty string in camera constructor. So in application
call the control for loading calibration and constructing json from module FLASH memory

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>