### PR TITLE
added api for onlyABflag enable/disable

### DIFF
--- a/sdk/include/aditof/camera.h
+++ b/sdk/include/aditof/camera.h
@@ -182,6 +182,12 @@ class SDK_API Camera {
      */
     virtual Status getTemperatureSensors(
         std::vector<std::shared_ptr<TemperatureSensorInterface>> &sensors) = 0;
+    
+    /**
+     * @brief Enables/disables the onlyAB option in depth engine.     
+     * @param[in] options- 1 for disable , 0 for enable
+     */
+    virtual void onlyABFlag(int option) = 0;
 };
 
 } // namespace aditof

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -958,3 +958,8 @@ aditof::Status CameraItof::saveCCBToFile(const std::string &filePath) const {
 
     return aditof::Status::OK;
 }
+
+void CameraItof::onlyABFlag(int option)
+{    
+    tofi_onlyABFlag(m_tofi_compute_context,option);
+}

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -281,6 +281,14 @@ class CameraItof : public aditof::Camera {
      */
     aditof::Status saveCCBToFile(const std::string &filePath) const;
 
+    /**
+     * @brief Function to enable/disable onlyAB flag
+     * @param[in] TofiConfig *p_tofi_cal_config: pointer to the TOFI
+     * @param[in] int option: '1' for enable & '0' for disable
+     * @return None
+     */
+    void onlyABFlag(int option);
+
   private:
     using noArgCallable = std::function<aditof::Status()>;
 

--- a/sdk/src/cameras/itof-camera/tofi/tofi_compute.h
+++ b/sdk/src/cameras/itof-camera/tofi/tofi_compute.h
@@ -80,6 +80,11 @@ TOFI_COMPUTE_API int TofiCompute(
 TOFI_COMPUTE_API void FreeTofiCompute(
     TofiComputeContext *p_tofi_compute_context);
 
+/// Function to enable/disable onlyAB flag
+/// @param[in] TofiConfig *p_tofi_cal_config: pointer to the TOFI
+/// @param[in] option: '1' for enable & '0' for disable
+void tofi_onlyABFlag(TofiComputeContext *const p_tofi_compute_context, int option);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sdk/src/connections/target/adsd3100_sensor.cpp
+++ b/sdk/src/connections/target/adsd3100_sensor.cpp
@@ -684,7 +684,7 @@ void saveFrame(std::string id, char* data, size_t size){
 
 aditof::Status Adsd3100Sensor::getFrame(uint16_t *buffer) {
      using namespace aditof;
-    struct v4l2_buffer buf[MAX_SUBFRAMES_COUNT];
+    struct v4l2_buffer buf[MAX_SUBFRAMES_COUNT] , buf_discard;
     struct VideoDev *dev;
     Status status;
     unsigned int buf_data_len;
@@ -693,6 +693,13 @@ aditof::Status Adsd3100Sensor::getFrame(uint16_t *buffer) {
     dev = &m_implData->videoDevs[0];
 
     for (int idx = 0; idx < m_capturesPerFrame; idx++) {
+		
+		//Hack to force clear all queued buffers and get latest capture
+        for (int buff_nr = 0;  buff_nr < dev->nVideoBuffers; buff_nr ++) {
+            dequeueInternalBufferPrivate(buf_discard, dev);
+            enqueueInternalBufferPrivate(buf_discard, dev);
+        }
+		
         status = waitForBufferPrivate(dev);
         if (status != Status::OK) {
             return status;


### PR DESCRIPTION
while preview streaming from original sdk  with mode 7 and depth enables, we found that fps is around 2 and wanted it to increase. SO in depth compute engine, we introduced a flag which generated only AB image and skips other filtering. 

So this changes is to access tofi compute engine only AB flag via SDK. 