### PR TITLE
Hide passive IR (PCM) mode from tof-viewer example

### DIFF
--- a/examples/tof-viewer/CMakeLists.txt
+++ b/examples/tof-viewer/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.10)
 # set the project name
 project(ADIToFGUI)
 
+option(ENBABLE_PASSIVE_IR "Allow passive IR (PCM) mode" OFF)
+
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -81,6 +83,11 @@ target_include_directories(ADIToFGUI PUBLIC
 
 target_include_directories(ADIToFGUI PUBLIC
                         "${CMAKE_SOURCE_DIR}/sdk/src/cameras/itof-camera")
+
+if (ENBABLE_PASSIVE_IR)
+	message(STATUS "Building with Passive IR Mode enabled")
+	add_definitions(-DENBABLE_PASSIVE_IR)
+endif()
 
 # Copying necessary dlls from SDK and the necessary config files
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD


### PR DESCRIPTION
* Added cmake option to reenable PCM in viewer at build time
* Resolved several GUI crash/unstable cases:
   1. playing recording with no camera attache
   2. starting recording when camera not already "playing"
   3. switching mode while streaming
   4. switching mode resolution from higher-2-lower or lower-2-higher