### PR TITLE
USB 3 updates

### DIFF
--- a/sdcard-images-utils/nxp/deboot.sh
+++ b/sdcard-images-utils/nxp/deboot.sh
@@ -227,9 +227,7 @@ apt install -y ${ADD_LIST_ST_3}
 #systemd configs
 systemctl enable systemd-networkd.service
 systemctl enable avahi-daemon.service
-systemctl enable usb-gadget-uvc.service
 systemctl enable uvc-gadget.service
-systemctl enable adi-tof.service
 
 #sdk install
 pushd /home/${USERNAME}

--- a/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
@@ -1,7 +1,7 @@
-From a13e75564ff3e8102ca3f36385fa0a663aa9b781 Mon Sep 17 00:00:00 2001
+From 09f305754f27c384d2eebb701db3896eb53b1cc4 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 15 Apr 2021 11:26:07 +0300
-Subject: [PATCH 01/16] Enable I2C in PMIC
+Subject: [PATCH 01/21] Enable I2C in PMIC
 
 Signed-off-by: TalPilo <tal.pilo@solid-run.com>
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -28,5 +28,5 @@ index 247de3e68d81..d0c74f896849 100644
  		const struct regulator_desc *desc;
  		struct regulator_dev *rdev;
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
@@ -1,7 +1,7 @@
-From 68136a92df0e4b3faa3f844ff1a6902bf688c364 Mon Sep 17 00:00:00 2001
+From 63bf78c9c1b13851f3eed773db650b39e0507ce7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:26:52 +0200
-Subject: [PATCH 02/16] media: spi: Add initial support for addicmos camera
+Subject: [PATCH 02/21] media: spi: Add initial support for addicmos camera
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -1003,5 +1003,5 @@ index a184c4939438..21e3b433856a 100644
  /* The MPEG controls are applicable to all codec controls
   * and the 'MPEG' part of the define is historical */
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
@@ -1,7 +1,7 @@
-From fd63be0e5547ba930e3abb7b850878ff62994641 Mon Sep 17 00:00:00 2001
+From 5f6133a8dfff43ccfeafe845d263b75a408594d8 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:35:17 +0200
-Subject: [PATCH 03/16] Changes for ADI camera required on I.MX8M Plus capture
+Subject: [PATCH 03/21] Changes for ADI camera required on I.MX8M Plus capture
  driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -102,5 +102,5 @@ index 6bfd01315b85..a8d323625fd8 100644
  	return 0;
  }
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
@@ -1,7 +1,7 @@
-From 10cc055436456d34b752777134878e6bdf86acae Mon Sep 17 00:00:00 2001
+From a33e118551ecba5766c0b197d444ada2f4ab9cb8 Mon Sep 17 00:00:00 2001
 From: btogorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Apr 2021 11:44:38 +0300
-Subject: [PATCH 04/16] drivers: staging: media: imx8: Convert to single planar
+Subject: [PATCH 04/21] drivers: staging: media: imx8: Convert to single planar
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -341,5 +341,5 @@ index 9adb71d69ffc..29199b38cc85 100644
  
  	val = readl(mxc_isi->regs + CHNL_OUT_BUF_CTRL);
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
@@ -1,7 +1,7 @@
-From 6fe404c817b6ea8a874ff8b7cdbf984d32070895 Mon Sep 17 00:00:00 2001
+From 731e6701228cac85f2141240fa2977f856608005 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 22 Apr 2021 09:36:10 +0300
-Subject: [PATCH 05/16] Convert pixel format to YUYV
+Subject: [PATCH 05/21] Convert pixel format to YUYV
 
 Signed-off-by: btogorean <bogdan.togorean@analog.com>
 ---
@@ -50,5 +50,5 @@ index 344d42dbbaa6..5bfd73bf47da 100644
  		.memplanes	= 1,
  		.colplanes	= 1,
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0006-arch-arm64-dts-ADI-TOF-dt.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0006-arch-arm64-dts-ADI-TOF-dt.patch
@@ -1,7 +1,7 @@
-From 9117e692dd107b8de56ec9490fb545c94b750814 Mon Sep 17 00:00:00 2001
+From 396828b8e4e25cb5cd9d5af3510025d588640c1c Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 16 Apr 2021 09:03:47 +0300
-Subject: [PATCH 06/16] arch: arm64: dts: ADI TOF dt
+Subject: [PATCH 06/21] arch: arm64: dts: ADI TOF dt
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -1230,5 +1230,5 @@ index 000000000000..ae0e5bb9eeae
 +	status = "okay";
 +};
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
@@ -1,7 +1,7 @@
-From 4caf7bde687d5ebebe4cc069387d28d9911b4a90 Mon Sep 17 00:00:00 2001
+From 755bacd5497c8eca1baf3c481ab8d9d3019e4aa6 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 4 May 2021 10:20:23 +0300
-Subject: [PATCH 07/16] staging: media: imx: imx8-isi-cap : Fix for discarding
+Subject: [PATCH 07/21] staging: media: imx: imx8-isi-cap : Fix for discarding
  of the first frame
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -29,5 +29,5 @@ index 5bfd73bf47da..8c16ffdcfeed 100644
  	/* ISI channel output buffer 2 */
  	buf = list_first_entry(&isi_cap->out_pending, struct mxc_isi_buffer, list);
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
@@ -1,7 +1,7 @@
-From ccae4ae3dc9f6f706a548815a7c0f0bec5e2c4fd Mon Sep 17 00:00:00 2001
+From 6ab5b6dea1d95a7519f0caf0b19cc3f110ec3105 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 11:49:25 +0300
-Subject: [PATCH 08/16] drivers: usb: gadget: Add XU control descriptor
+Subject: [PATCH 08/21] drivers: usb: gadget: Add XU control descriptor
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -157,5 +157,5 @@ index d854cb19c42c..6687ebb7c312 100644
  } __attribute__((__packed__));
  
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
@@ -1,7 +1,7 @@
-From c29acf628bed8e4b4e4d38fb0a26b203fe383616 Mon Sep 17 00:00:00 2001
+From ed47fe7e808af20219b371b3b89ebce9ad288121 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:05:06 +0300
-Subject: [PATCH 09/16] drivers: staging: media: imx: imx8-isi-cap: Add debug
+Subject: [PATCH 09/21] drivers: staging: media: imx: imx8-isi-cap: Add debug
  msg for dropped frames
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -22,5 +22,5 @@ index 8c16ffdcfeed..3d68e8c19085 100644
  		list_move_tail(isi_cap->out_discard.next, &isi_cap->out_active);
  		return;
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
@@ -1,7 +1,7 @@
-From 42586b808fd70d10f3ad08fd3655fbfb0b5103ec Mon Sep 17 00:00:00 2001
+From 0895eec0c8db8f9b4c18d82d5c73e6b8be74c82f Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:07:14 +0300
-Subject: [PATCH 10/16] drivers: media: spi: addicmos: Add resolutions for max
+Subject: [PATCH 10/21] drivers: media: spi: addicmos: Add resolutions for max
  frames FW
 
 When firmware configured for setting frame-end only after all
@@ -45,5 +45,5 @@ index e6bbb45d8116..94a37e3bdd07 100644
  };
  
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
@@ -1,7 +1,7 @@
-From 930033be469aa64030eb63612cd0163d6a5098b5 Mon Sep 17 00:00:00 2001
+From c38c11b162c507e150ed7c845265cb0dd3724a5f Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:10:33 +0300
-Subject: [PATCH 11/16] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
+Subject: [PATCH 11/21] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
  20V and add SPI flash
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index ae0e5bb9eeae..28924e4bc0f9 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -215,7 +215,7 @@ usb3_data_ss: endpoint {
+@@ -215,7 +215,7 @@
  
  	mpcie {
  		pinctrl-names = "default";
@@ -22,7 +22,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  		gpio-0 = <&gpio1 1 GPIO_ACTIVE_HIGH>;
  		gpio-1 = <&gpio1 5 GPIO_ACTIVE_HIGH>;
  		status = "okay";
-@@ -239,23 +239,23 @@ &snvs_rtc{
+@@ -239,23 +239,23 @@
  
  /*eth0*/
  &eqos {
@@ -63,7 +63,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &i2c1 {
-@@ -265,10 +265,10 @@ &i2c1 {
+@@ -265,10 +265,10 @@
  	status = "okay";
  
  	eeprom: eeprom@50{
@@ -78,7 +78,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  
  	pmic: pca9450@25 {
  		reg = <0x25>;
-@@ -437,20 +437,21 @@ mipi_csi0_ep: endpoint {
+@@ -437,20 +437,21 @@
  };
  
  &ecspi2 {
@@ -106,7 +106,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  
  		port {
  			addicmos_ep: endpoint {
-@@ -461,6 +462,18 @@ addicmos_ep: endpoint {
+@@ -461,6 +462,18 @@
  			};
  		};
  	};
@@ -125,7 +125,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &isp_0 {
-@@ -499,9 +512,9 @@ usb_con: connector {
+@@ -499,9 +512,9 @@
  			compatible = "usb-c-connector";
  			label = "USB-C";
  			power-role = "sink";
@@ -137,7 +137,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  			op-sink-microwatt = <15000000>;
  
  			ports {
-@@ -712,7 +725,7 @@ &usdhc3 {
+@@ -712,7 +725,7 @@
  	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
  	bus-width = <8>;
  	non-removable;
@@ -146,7 +146,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &wdog1 {
-@@ -1077,19 +1090,31 @@ MX8MP_IOMUXC_GPIO1_IO06__GPIO1_IO06		0x19
+@@ -1077,19 +1090,31 @@
  
  	pinctrl_ecspi2: ecspi2grp {
  		fsl,pins = <
@@ -181,5 +181,5 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  		fsl,pins = <
  			MX8MP_IOMUXC_SPDIF_RX__GPIO5_IO04		0x140
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
@@ -1,7 +1,7 @@
-From 3068e59bed762137069047ae4db2bd3bcacb5793 Mon Sep 17 00:00:00 2001
+From 953c1acaf78f4fee559fadd91fd2169ae920dc14 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 16 Apr 2021 09:01:34 +0300
-Subject: [PATCH 12/16] usb: typec: tcpm: Remove tcpm port reset
+Subject: [PATCH 12/21] usb: typec: tcpm: Remove tcpm port reset
 
 This patch is required to prevent VBUS turning off by the HOST when PD negociation is happening
 
@@ -177,5 +177,5 @@ index 3a805e2ecbc9..c5184ef96769 100644
  #define PD_T_SRC_TRANSITION	35
  #define PD_T_DRP_SNK		40
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
@@ -1,7 +1,7 @@
-From 306db96d9e9dff61a9d9d8b9abe5a86f4a9c1787 Mon Sep 17 00:00:00 2001
+From c1e10da3279bb167eca919fa7699ee4cbc955ed2 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 22 Jun 2021 17:08:26 +0300
-Subject: [PATCH 13/16] drivers: usb: gadget: function: uvc_configfs: Set guid
+Subject: [PATCH 13/21] drivers: usb: gadget: function: uvc_configfs: Set guid
  to "Y16"
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -23,5 +23,5 @@ index 5dec2a126fd2..16ba47ee4d9b 100644
  	};
  	struct uvcg_uncompressed *h;
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
@@ -1,7 +1,7 @@
-From 1bb0715ee5157777200dda650cbc9bc78963b47e Mon Sep 17 00:00:00 2001
+From b2ab0db974a0075a8682c0a75cea55ac9c4effca Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:07:54 +0300
-Subject: [PATCH 14/16] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
+Subject: [PATCH 14/21] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
  on flash WP
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index 28924e4bc0f9..06332e91004a 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -1111,7 +1111,7 @@ MX8MP_IOMUXC_ECSPI2_MOSI__GPIO5_IO11		0x100 /* MOSI pin as GPIO with pull-down *
+@@ -1111,7 +1111,7 @@
  
  	pinctrl_nvram_gpio: nvram-gpio-grp {
  		fsl,pins = <
@@ -23,5 +23,5 @@ index 28924e4bc0f9..06332e91004a 100644
  	};
  
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
@@ -1,7 +1,7 @@
-From 2e91c74d3461a947d6a9d71b493c3662719bb40f Mon Sep 17 00:00:00 2001
+From 72da9c1e03ef3a59b2ee1d94a9e7bc2d3dd81276 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:08:46 +0300
-Subject: [PATCH 15/16] drivers: media: spi: addicmos: Add custom control for
+Subject: [PATCH 15/21] drivers: media: spi: addicmos: Add custom control for
  config/claib writing
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -142,5 +142,5 @@ index 94a37e3bdd07..14faf522d39f 100644
  	if (ret) {
  		dev_err(dev, "%s: control initialization error %d\n",
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
@@ -1,7 +1,7 @@
-From b37ee77e8391704320f7efafccae683ce6c4659a Mon Sep 17 00:00:00 2001
+From b5f7f7f8f7ee5bb104a0ca3262df0e02e176e219 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 23 Jul 2021 09:07:30 +0300
-Subject: [PATCH 16/16] adrivers: media: spi: addicmos.c: Add resolution for
+Subject: [PATCH 16/21] adrivers: media: spi: addicmos.c: Add resolution for
  mode 10
 
 Mode 10 require 4096x256x9 subframes so add corresponding resolution. Also disable default writing of calibration data.
@@ -15,14 +15,14 @@ diff --git a/drivers/media/spi/addicmos.c b/drivers/media/spi/addicmos.c
 index 14faf522d39f..24ce8e03988f 100644
 --- a/drivers/media/spi/addicmos.c
 +++ b/drivers/media/spi/addicmos.c
-@@ -154,6 +154,7 @@ static const s64 link_freq_tbl[] = {
- 	732000000,
- 	732000000,
- 	732000000,
-+	732000000,
- 	732000000
+@@ -150,6 +150,7 @@ static const struct reg_sequence addicmos_standby_setting[] = {
  };
  
+ static const s64 link_freq_tbl[] = {
++	732000000,
+ 	732000000,
+ 	732000000,
+ 	732000000,
 @@ -185,9 +186,15 @@ static const struct addicmos_mode_info addicmos_mode_info_data[] = {
  	},
  	{
@@ -52,5 +52,5 @@ index 14faf522d39f..24ce8e03988f 100644
  			addicmos_powerup_setting,
  			ARRAY_SIZE(addicmos_powerup_setting));
 -- 
-2.32.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
@@ -1,7 +1,7 @@
-From 4efe0fc7589890bc9fda7e8b894f7ba60796c80d Mon Sep 17 00:00:00 2001
+From 8e2bae219a4d72c568cd0c51e2968fc538772cd1 Mon Sep 17 00:00:00 2001
 From: Olliver Schinagl <oliver@schinagl.nl>
 Date: Mon, 26 Oct 2015 22:32:38 +0100
-Subject: [PATCH 17/18] pwm: gpio: Add a generic gpio based PWM driver
+Subject: [PATCH 17/21] pwm: gpio: Add a generic gpio based PWM driver
 
 This patch adds a bit-banging gpio PWM driver. It makes use of hrtimers,
 to allow nano-second resolution, though it obviously strongly depends on
@@ -345,5 +345,5 @@ index 000000000000..7e9ffcc1c547
 +MODULE_DESCRIPTION("Generic GPIO bit-banged PWM driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.33.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
@@ -1,7 +1,7 @@
-From a8609e458710d68cb10f81c9c3b3cc03456ca477 Mon Sep 17 00:00:00 2001
+From 1f65663a054458ba3a7d1cb4b501dd6ae60935a7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 17 Sep 2021 11:52:08 +0300
-Subject: [PATCH 18/18] Add FSYNC control using PWM framework
+Subject: [PATCH 18/21] Add FSYNC control using PWM framework
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index 06332e91004a..a7521545f245 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -221,6 +221,12 @@ mpcie {
+@@ -221,6 +221,12 @@
  		status = "okay";
  		enable-active-high;
  	};
@@ -26,7 +26,7 @@ index 06332e91004a..a7521545f245 100644
  };
  
  &clk {
-@@ -452,6 +458,8 @@ addicmos@0 {
+@@ -452,6 +458,8 @@
  		pinctrl-names = "spi", "gpio";
  		pinctrl-0 = <&pinctrl_addicmos_spi>;
  		pinctrl-1 = <&pinctrl_addicmos_gpio>;
@@ -235,5 +235,5 @@ index 24ce8e03988f..66a2bbf48cec 100644
  
  	addicmos->pixel_rate = v4l2_ctrl_new_std(&addicmos->ctrls,
 -- 
-2.33.0
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
@@ -1,0 +1,31 @@
+From c3863e0a78ab903ba5d8f7b5c6bcdf231583faae Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Thu, 7 Oct 2021 16:10:47 +0300
+Subject: [PATCH] usb: gadget: Set lowest allowed speed to SS
+
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
+---
+ drivers/usb/gadget/composite.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/usb/gadget/composite.c b/drivers/usb/gadget/composite.c
+index 1a556a628971..5307bab3ed5d 100644
+--- a/drivers/usb/gadget/composite.c
++++ b/drivers/usb/gadget/composite.c
+@@ -722,11 +722,9 @@ static int bos_desc(struct usb_composite_dev *cdev)
+ 		ss_cap->bDescriptorType = USB_DT_DEVICE_CAPABILITY;
+ 		ss_cap->bDevCapabilityType = USB_SS_CAP_TYPE;
+ 		ss_cap->bmAttributes = 0; /* LTM is not supported yet */
+-		ss_cap->wSpeedSupported = cpu_to_le16(USB_LOW_SPEED_OPERATION |
+-						      USB_FULL_SPEED_OPERATION |
+-						      USB_HIGH_SPEED_OPERATION |
++		ss_cap->wSpeedSupported = cpu_to_le16(USB_HIGH_SPEED_OPERATION |
+ 						      USB_5GBPS_OPERATION);
+-		ss_cap->bFunctionalitySupport = USB_LOW_SPEED_OPERATION;
++		ss_cap->bFunctionalitySupport = 3; /* USB_SS_OPERATION */
+ 		ss_cap->bU1devExitLat = dcd_config_params.bU1devExitLat;
+ 		ss_cap->bU2DevExitLat = dcd_config_params.bU2DevExitLat;
+ 	}
+-- 
+2.17.1
+

--- a/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
@@ -1,7 +1,7 @@
-From c3863e0a78ab903ba5d8f7b5c6bcdf231583faae Mon Sep 17 00:00:00 2001
+From 317d44d7ae1cdae5631ead20fef0791afb091066 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 7 Oct 2021 16:10:47 +0300
-Subject: [PATCH] usb: gadget: Set lowest allowed speed to SS
+Subject: [PATCH 19/21] usb: gadget: Set lowest allowed speed to SS
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
@@ -1,0 +1,172 @@
+From ee6fe4556a3560941b0b9571816416a4c5bceff0 Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Mon, 8 Nov 2021 11:00:31 +0200
+Subject: [PATCH 20/21] drivers: media: addicmos: Add module parameter to
+ enable FW/Calib loading
+
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
+---
+ drivers/media/spi/addicmos.c | 75 ++++++++++++++++++++++--------------
+ 1 file changed, 47 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/media/spi/addicmos.c b/drivers/media/spi/addicmos.c
+index 66a2bbf48cec..76039eaa179d 100644
+--- a/drivers/media/spi/addicmos.c
++++ b/drivers/media/spi/addicmos.c
+@@ -22,6 +22,14 @@
+ #define FW_FILE_NAME	"adi/addicmos-fw.bin"
+ #define ADDI_MAGIC	"ADDICMOS"
+ 
++static bool fw_load = false;
++module_param(fw_load, bool, 0644);
++MODULE_PARM_DESC(fw_load, "Boolean enabling/disabling FW loading by driver");
++
++static bool calib_load = false;
++module_param(calib_load, bool, 0644);
++MODULE_PARM_DESC(calib_load, "Boolean enabling/disabling Calibration loading by driver");
++
+ struct addicmos_mode_info {
+ 	u32 width;
+ 	u32 height;
+@@ -276,7 +284,7 @@ static int addicmos_power_on(struct device *dev)
+ 	if (ret)
+ 		dev_err(addicmos->dev, "Could not set power up register\n");
+ 
+-	for (i = 0; i < 5; i ++) {
++	for (i = 0; i < 10; i ++) {
+ 		msleep_interruptible(15);
+ 		regmap_read(addicmos->regmap, 0x256, &read_val);
+ 		if (read_val == 0x2) {
+@@ -285,6 +293,7 @@ static int addicmos_power_on(struct device *dev)
+ 	}
+ 
+ 	dev_err(addicmos->dev, "Power on timed out.\n");
++	dev_dbg(addicmos->dev, "Status register 0x256 value: %x\n", read_val);
+ 	regmap_read(addicmos->regmap, 0x32, &read_val);
+ 	dev_dbg(addicmos->dev, "Status register 0x32 value: %x\n", read_val);
+ 
+@@ -299,6 +308,9 @@ static int addicmos_power_off(struct device *dev)
+ 	unsigned int read_val;
+ 	int i, ret;
+ 
++	if (!addicmos->streaming)
++		return 0;
++
+ 	dev_dbg(addicmos->dev, "Entered addicmos_power_off\n");
+ 
+ 	ret = regmap_write(addicmos->regmap, 0xC, 0x2);
+@@ -309,11 +321,11 @@ static int addicmos_power_off(struct device *dev)
+ 		msleep_interruptible(100);
+ 		regmap_read(addicmos->regmap, 0xC, &read_val);
+ 		if (read_val == 0x0) {
+-			pwm_disable(addicmos->pwm_fsync);
+ 			return 0;
+ 		}
+ 	}
+ 
++	pwm_disable(addicmos->pwm_fsync);
+ 	dev_err(addicmos->dev, "Power off timed out.\n");
+ 	regmap_read(addicmos->regmap, 0x32, &read_val);
+ 	dev_dbg(addicmos->dev, "Status register 0x32 value: %x\n", read_val);
+@@ -608,14 +620,20 @@ static int addicmos_start_streaming(struct addicmos *addicmos)
+ 	}
+ 
+ 	ret = pwm_enable(addicmos->pwm_fsync);
++	if (ret)
++		dev_err(addicmos->dev, "Could not enable FSYNC PWM\n");
++
++	addicmos->streaming = true;
+ 
+ 	return ret;
+ }
+ 
+ static int addicmos_stop_streaming(struct addicmos *addicmos)
+ {
+-	int ret = 0;
+-	return ret;
++	pwm_disable(addicmos->pwm_fsync);
++	addicmos->streaming = false;
++
++	return 0;
+ }
+ 
+ static int addicmos_s_stream(struct v4l2_subdev *subdev, int enable)
+@@ -646,7 +664,6 @@ static int addicmos_s_stream(struct v4l2_subdev *subdev, int enable)
+ 		pm_runtime_put(addicmos->dev);
+ 	}
+ 
+-	addicmos->streaming = enable;
+ 	mutex_unlock(&addicmos->lock);
+ 
+ 	return ret;
+@@ -670,7 +687,7 @@ static int addicmos_g_frame_interval(struct v4l2_subdev *subdev,
+ 
+ 	fi->interval.numerator = 1;
+ 	fi->interval.denominator =
+-		(u32)pwm_get_period(addicmos->pwm_fsync) / NSEC_PER_SEC;
++		(u32)(NSEC_PER_SEC / pwm_get_period(addicmos->pwm_fsync));
+ 	dev_dbg(addicmos->dev, "%s frame rate = %u / %u\n", __func__,
+ 		fi->interval.numerator, fi->interval.denominator);
+ 
+@@ -835,34 +852,36 @@ static int addicmos_g_sensor_firmware(struct v4l2_subdev *sd)
+ static int addicmos_firmware_load(struct v4l2_subdev *sd)
+ {
+ 	struct addicmos *addicmos = to_addicmos(sd);
+-	int ret;
++	int ret = 0;
+ 
+-	ret = request_firmware(&addicmos->fw, FW_FILE_NAME, addicmos->dev);
+-	if (ret < 0) {
+-		dev_err(addicmos->dev, "FW request failed\n");
+-		return ret;
+-	}
++	if (fw_load) {
++		ret = request_firmware(&addicmos->fw, FW_FILE_NAME, addicmos->dev);
++		if (ret < 0) {
++			dev_err(addicmos->dev, "FW request failed\n");
++			goto release_firmware;
++		}
+ 
+-	ret = addicmos_g_sensor_firmware(sd);
++		ret = addicmos_g_sensor_firmware(sd);
++		if (ret < 0) {
++			dev_err(addicmos->dev, "FW parsing failed\n");
++			goto release_firmware;
++		}
+ 
+-	ret = regmap_multi_reg_write(addicmos->regmap, addicmos->fw_regs,
+-				     addicmos->fw_regs_count);
+-	if (ret)
+-		dev_err(addicmos->dev, "Could not write firmware to camera\n");
++		/* Writes for Default firmware */
++		regmap_multi_reg_write(addicmos->regmap, addicmos->fw_regs,
++					     addicmos->fw_regs_count);
++	}
+ 
+-	release_firmware(addicmos->fw);
+-	if (ret < 0) {
+-		dev_err(addicmos->dev, "FW parsing failed\n");
+-		return ret;
++	if (calib_load) {
++		/* Writes for Default calibration */
++		regmap_multi_reg_write(addicmos->regmap,
++				       addicmos_powerup_setting,
++				       ARRAY_SIZE(addicmos_powerup_setting));
+ 	}
+ 
+-	//Writes for Default calibration - disabled
+-#if 0
+-	regmap_multi_reg_write(addicmos->regmap,
+-			addicmos_powerup_setting,
+-			ARRAY_SIZE(addicmos_powerup_setting));
+-#endif
+-	return 0;
++release_firmware:
++	release_firmware(addicmos->fw);
++	return ret;
+ }
+ 
+ static int addicmos_probe(struct spi_device *client)
+-- 
+2.17.1
+

--- a/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
@@ -1,0 +1,34 @@
+From 05916e5615ac11e8f58a3bf8cc67ba238b8a11cc Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Mon, 8 Nov 2021 11:01:37 +0200
+Subject: [PATCH 21/21] arch: arm64: imx8mp-adi-tof-noreg: Increase CMA size
+
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+index a7521545f245..87d81263e6a1 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+@@ -229,6 +229,16 @@
+ 	};
+ };
+ 
++&resmem {
++	linux,cma {
++			compatible = "shared-dma-pool";
++			reusable;
++			size = <0 0x20000000>;
++			alloc-ranges = <0 0x40000000 0 0xC0000000>;
++			linux,cma-default;
++		};
++};
++
+ &clk {
+ 	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
+ };
+-- 
+2.17.1
+

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/adi-tof.service
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/adi-tof.service
@@ -3,8 +3,9 @@ Description=Analog Devices TOF sensor service
 After=usb-gadget.target
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/share/systemd/tof-power-en.sh
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/usb-gadget-uvc.service
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/usb-gadget-uvc.service
@@ -4,9 +4,9 @@ Requires=sys-kernel-config.mount
 After=sys-kernel-config.mount
 
 [Service]
+Type=oneshot
 ExecStart=/usr/share/systemd/uvc-gadget.sh start
 ExecStop=/usr/share/systemd/uvc-gadget.sh stop
-Type=simple
 RemainAfterExit=yes
 
 [Install]

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/uvc-gadget.service
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/lib/systemd/system/uvc-gadget.service
@@ -3,7 +3,7 @@ Description=UVC application service
 Wants=adi-tof.service usb-gadget-uvc.service
 
 [Service]
-Type=simple
+Type=exec
 ExecStart=/usr/share/systemd/uvc-gadget
 Restart=on-failure
 RestartSec=1

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
@@ -106,6 +106,6 @@ echo "V5V0 is $VALUE V"
 fi
 done # Reads back channel 0..7 and temperature (channel #8)
 
-modprobe addicmos
+modprobe addicmos fw_load=1 calib_load=0
 modprobe imx8_media_dev
 modprobe spi_nor

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/uvc-gadget.sh
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/uvc-gadget.sh
@@ -203,6 +203,8 @@ case "$1" in
 	echo "Creating Config"
 	mkdir configs/c.1
 	mkdir configs/c.1/strings/0x409
+	#set requested power to 900mA
+	echo 900 > configs/c.1/MaxPower
 
 	echo "Creating functions..."
 	#create_msd configs/c.1 mass_storage.0 $USBFILE


### PR DESCRIPTION
This patch propose 3 commits which:
1. Set lowest usable speed to SS in USB descriptors. This can solve the problem with camera being enumerated as USB2 device on some hosts
2. Increase preallocated CMA size to avoid warnings in Linux DMESG
3. Rearrange systemd services to have one-shot services that remain after exit. This will ensure that for example the service controlling the power supplies is run only one and does not cut power of camera by being recalled