### PR TITLE
Add SD card creator.

### DIFF
--- a/sdcard-images-utils/nxp/README.md
+++ b/sdcard-images-utils/nxp/README.md
@@ -20,6 +20,6 @@ For SD card bootable images, plug in a microSD and run the following, where sdX 
 
 Take care S3 boot switches to be configured accordingly.
 
-## Work In Progress
-		2. Automatic resize of the ROOTFS partition is not performed. Depending on the SD card the user can resize
-		partition 2 to fill the whole SD card. Don't forget to "e2fsck -f /dev/sdX" and "resize2fs /dev/sdX"
+## SD card creator
+To write a image into a sdcard, run
+`create_sd.sh images/microsd-ae93cfb.img /dev/sdc`

--- a/sdcard-images-utils/nxp/create_sd.sh
+++ b/sdcard-images-utils/nxp/create_sd.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+help()
+{
+	echo "Usage: ./`basename $0` image_image sdcard_dev_name" 
+	exit 0
+}
+
+IMAGE=$1
+DISK=$2
+RFS_PART=2
+
+if [ "x$1" == "x"  -o "x$2" == "x" ]; then
+    help
+    exit -1
+fi
+
+echo "`basename $0` $1 $2"
+
+DISK_REMOVABLE=`lsblk ${DISK} | grep disk | awk '{ print $3 }'`
+if [ "x$DISK_REMOVABLE" != "x1" ]; then
+	echo "You are not writing image to a removable disk, please check it."
+	exit -1
+fi
+
+sudo dd if=${IMAGE} of=${DISK} bs=1M status=progress
+
+sudo sync
+
+echo "Resize the rootfs partition"
+
+sudo parted -s ${DISK} "resizepart ${RFS_PART} -1" quit
+sudo e2fsck -f ${DISK}${RFS_PART}
+sudo resize2fs ${DISK}${RFS_PART}
+
+sudo sync
+
+echo "Done..."


### PR DESCRIPTION
Add a simple script to write boot image to sd card and extend the rootfs to use the whole disk space. 
Tested with usb to sd card adapter.