### PR TITLE
sdk: itof-camera: camera_itof.cpp: Add check for USEQ runnig state

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -223,6 +223,15 @@ aditof::Status CameraItof::start() {
 
     // Program the camera firmware only once, re-starting requires
     // only setmode and start the camera.
+    uint16_t reg_address = 0x256;
+    uint16_t reg_data;
+    m_depthSensor->readRegisters(&reg_address, &reg_data, 1);
+
+    if (reg_data) {
+        m_CameraProgrammed = true;
+        LOG(INFO) << "USEQ running. Skip CFG & CCB programming step\n";
+    }
+
     if (!m_CameraProgrammed) {
         CalibrationItof calib(m_depthSensor);
 


### PR DESCRIPTION
If USEQ is initialized and is in running or idle state don't program
the CCB and CFG again. In order to modify the CCB or CFG loaded in
imager module a power cycle must be performed.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>