### PR TITLE
Add create_sd.sh to burn image to sd card and extend the partition size of rootfs automatically.

### DIFF
--- a/sdcard-images-utils/nxp/README.md
+++ b/sdcard-images-utils/nxp/README.md
@@ -27,6 +27,9 @@ For SD card bootable images, plug in a microSD and run the following, where sdX 
 
 Take care S3 boot switches to be configured accordingly.
 
-## Work In Progress
-		2. Automatic resize of the ROOTFS partition is not performed. Depending on the SD card the user can resize
-		partition 2 to fill the whole SD card. Don't forget to "e2fsck -f /dev/sdX" and "resize2fs /dev/sdX"
+## SD card creator
+To write a image into a sdcard, run
+
+`create_sd.sh images/microsd-xxxxxxx.img /dev/sdX`
+
+The package hdparm is required to notify the partition change to the kernel. Please install it with your package management system.

--- a/sdcard-images-utils/nxp/create_sd.sh
+++ b/sdcard-images-utils/nxp/create_sd.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+help()
+{
+	echo "Usage: ./`basename $0` image_image sdcard_dev_name" 
+	exit 0
+}
+
+IMAGE=$1
+DISK=$2
+RFS_PART=2
+
+if [ "x$1" == "x"  -o "x$2" == "x" ]; then
+    help
+    exit -1
+fi
+
+echo "`basename $0` $1 $2"
+
+sudo dd if=/dev/zero of=${DISK} bs=1M count=3
+sudo dd if=${IMAGE} of=${DISK} bs=1M status=progress
+
+sudo sync
+sudo hdparm -z ${DISK}
+echo "Resize the rootfs partition"
+
+sudo parted -s ${DISK} "resizepart ${RFS_PART} -1" quit
+
+sudo hdparm -z ${DISK}
+
+sudo e2fsck -f ${DISK}${RFS_PART}
+sudo resize2fs ${DISK}${RFS_PART}
+
+sudo sync
+echo "Done..."


### PR DESCRIPTION
Add create_sd.sh to burn image to sd card and extend the partition size of rootfs automatically.
According to previous discussion, remove the REMOVABLE checking to allow working with mmcblkX

Additional hdparm command is required and is mentioned to notify user on the README.md page.