### PR TITLE
sdk: Check if storage exists

### DIFF
--- a/sdk/src/cameras/itof-camera/imx/sensor_enumerator_imx.cpp
+++ b/sdk/src/cameras/itof-camera/imx/sensor_enumerator_imx.cpp
@@ -145,11 +145,15 @@ Status TargetSensorEnumerator::searchSensors() {
         sInfo.captureDev = CAPTURE_DEVICE_NAME;
         m_sensorsInfo.emplace_back(sInfo);
     }
-
-    StorageInfo eepromInfo;
-    eepromInfo.driverName = EEPROM_NAME;
-    eepromInfo.driverPath = EEPROM_DEV_PATH;
-    m_storagesInfo.emplace_back(eepromInfo);
+    
+    // Check if EEPROM is available
+    struct stat st;
+    if (stat(EEPROM_DEV_PATH, &st) == 0) {
+        StorageInfo eepromInfo;
+        eepromInfo.driverName = EEPROM_NAME;
+        eepromInfo.driverPath = EEPROM_DEV_PATH;
+        m_storagesInfo.emplace_back(eepromInfo);
+    }
 
     return status;
 }


### PR DESCRIPTION
Don't assume that the driver for the storage exists

Signed-off-by: Dan Nechita <dan.nechita@analog.com>