### PR TITLE
Allow no EEPROM installed on Imager module usecase

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -207,9 +207,9 @@ aditof::Status CameraItof::initialize() {
             std::string name;
             m_eeprom->getName(name);
             LOG(ERROR) << "Failed to open EEPROM with name " << name;
-            return status;
+        } else {
+            m_eepromInitialized = true;
         }
-        m_eepromInitialized = true;
     }
 
     LOG(INFO) << "Camera initialized";

--- a/sdk/src/cameras/itof-camera/imx/sensor_enumerator_imx.cpp
+++ b/sdk/src/cameras/itof-camera/imx/sensor_enumerator_imx.cpp
@@ -145,11 +145,15 @@ Status TargetSensorEnumerator::searchSensors() {
         sInfo.captureDev = CAPTURE_DEVICE_NAME;
         m_sensorsInfo.emplace_back(sInfo);
     }
-
-    StorageInfo eepromInfo;
-    eepromInfo.driverName = EEPROM_NAME;
-    eepromInfo.driverPath = EEPROM_DEV_PATH;
-    m_storagesInfo.emplace_back(eepromInfo);
+    
+    // Check if EEPROM is available
+    struct stat st;
+    if (stat(EEPROM_DEV_PATH, &st) == 0) {
+        StorageInfo eepromInfo;
+        eepromInfo.driverName = EEPROM_NAME;
+        eepromInfo.driverPath = EEPROM_DEV_PATH;
+        m_storagesInfo.emplace_back(eepromInfo);
+    }
 
     return status;
 }


### PR DESCRIPTION
The usecase where no EEPROM chip is installed should be valid and we should not
fail camera initialize() if EEPROM is not detected. The only requirement is to have both 
CFG and CCB defined in .json config if no EEPROM chip is installed on imager module.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>