### PR TITLE
apps/server: Handle timeout for 3.1 and 3.2.3 versions of Websockets

### DIFF
--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -238,6 +238,8 @@ int main(int argc, char *argv[]) {
     signal(SIGINT, sigint_handler);
     signal(SIGTERM, sigint_handler);
 
+    LOG(INFO) << "Server built with websockets version:" << LWS_LIBRARY_VERSION;
+
     struct lws_context_creation_info info;
     memset(&info, 0, sizeof(info));
 
@@ -251,6 +253,13 @@ int main(int argc, char *argv[]) {
     network->context = lws_create_context(&info);
 
     Initialize();
+    int msTimeout;
+// TO DO: After 6-12 months we should remove this #if-else and keep only things related to 3.2.3
+#if LWS_LIBRARY_VERSION_NUMBER > 3002003
+    msTimeout = 0;
+#else
+    msTimeout = 50;
+#endif
 
 #if 0
   /* Note: Simply enabling this won't work, need libwebsocket compiled differently to demonize this */
@@ -261,7 +270,7 @@ int main(int argc, char *argv[]) {
 #endif
 
     while (!interrupted) {
-        lws_service(network->context, 0 /* timeout_ms */);
+        lws_service(network->context, msTimeout /* timeout_ms */);
     }
 
     if (sensors_are_created) {

--- a/sdk/src/system_impl.cpp
+++ b/sdk/src/system_impl.cpp
@@ -39,6 +39,10 @@
 
 #include "aditof/version.h"
 
+#ifdef HAS_NETWORK
+#include <lws_config.h>
+#endif
+
 using namespace aditof;
 
 static std::vector<std::shared_ptr<Camera>>
@@ -70,6 +74,10 @@ SystemImpl::SystemImpl() {
                   << " | branch: " << ADITOFSDK_GIT_BRANCH
                   << " | commit: " << ADITOFSDK_GIT_COMMIT;
         sdkRevisionLogged = true;
+#if HAS_NETWORK
+        LOG(INFO) << "SDK built with websockets version:"
+                  << LWS_LIBRARY_VERSION;
+#endif
     }
 }
 


### PR DESCRIPTION
With websockets 3.1 we need to set timeout to something greater than
0 (can be 50 ms) otherwise the server will take 100% of the CPU time.
On 3.2.3 we know things are handled internally and we can safely pass
0 milliseconds.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>