### PR TITLE
UVC app: Stability fixes

### DIFF
--- a/apps/uvc-app/uvc-gadget.cpp
+++ b/apps/uvc-app/uvc-gadget.cpp
@@ -753,22 +753,6 @@ static int uvc_video_process(struct uvc_device *dev) {
 
   dev->dqbuf_count++;
 
-  /*
-   * If the dequeued buffer was marked with state ERROR by the
-   * underlying UVC driver gadget, do not queue the same to V4l2
-   * and wait for a STREAMOFF event on UVC side corresponding to
-   * set_alt(0). So, now all buffers pending at UVC end will be
-   * dequeued one-by-one and we will enter a state where we once
-   * again wait for a set_alt(1) command from the USB host side.
-   */
-  if (ubuf.flags & V4L2_BUF_FLAG_ERROR) {
-    dev->uvc_shutdown_requested = 1;
-    printf("UVC: Possible USB shutdown requested from "
-           "Host, seen during VIDIOC_DQBUF\n");
-
-    return 0;
-  }
-
   CLEAR(vbuf);
 
   vbuf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;


### PR DESCRIPTION
1. Replace -r parameter from UVC app with -m (mode). When mode is set it will be propagated 
to both capture and streaming device and the two resolutions will be in sync.

2. Don't stop streaming if ERR flag is set. This will allow to drop one frame but after that recover and continue the streaming.